### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/RNLocalize.podspec
+++ b/RNLocalize.podspec
@@ -3,7 +3,7 @@ package = JSON.parse(File.read('./package.json'))
 
 Pod::Spec.new do |s|
   s.name                      = "RNLocalize"
-  s.dependency                  "React"
+  s.dependency                  "React-Core"
 
   s.version                   = package["version"]
   s.license                   = package["license"]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Xcode 12 won't build if a module depends on React instead of React-Core. 

Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Use this branch to install with an app running on Xcode 12.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
