### PR TITLE
Register receiver before the listener

### DIFF
--- a/android/src/main/java/com/zoontek/rnlocalize/RNLocalizeModule.java
+++ b/android/src/main/java/com/zoontek/rnlocalize/RNLocalizeModule.java
@@ -71,8 +71,8 @@ public class RNLocalizeModule extends ReactContextBaseJavaModule implements Life
       }
     };
 
-    reactContext.addLifecycleEventListener(this);
     reactContext.registerReceiver(mBroadcastReceiver, filter);
+    reactContext.addLifecycleEventListener(this);
   }
 
   @Override


### PR DESCRIPTION
Register the broadcast receiver before starting to listen for lifecycle events.
In the current state, I get calls to onHostDestroy right after this registers for lifecycle events but before the broadcast receiver is registered. 

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I upgraded to the latest RNLocalize and I got hundreds of crashes in Firebase Crashlytics over night.

The error trace is:
```
Caused by java.lang.IllegalArgumentException: Receiver not registered: com.zoontek.rnlocalize.RNLocalizeModule$1@98b572c
       at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:1499)
       at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1605)
       at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:678)
       at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:678)
       at com.zoontek.rnlocalize.RNLocalizeModule.onHostDestroy(RNLocalizeModule.java:116)
```

I could not reproduce the crash on my personal device, but looking in the code I figured that the only possible reason is that the registration order is wrong.

## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
