### PR TITLE
move initializers for static members

### DIFF
--- a/windows/RNLocalize/RNLocalizeModule.cpp
+++ b/windows/RNLocalize/RNLocalizeModule.cpp
@@ -11,6 +11,9 @@ using namespace winrt::Microsoft::ReactNative;
 namespace winrt::RNLocalize
 {
 
+/*static*/ const std::array<std::string, 6> RNLocalizeModule::USES_FAHRENHEIT{{"BS", "BZ", "KY", "PR", "PW", "US"}};
+/*static*/ const std::array<std::string, 3> RNLocalizeModule::USES_IMPERIAL{{"LR", "MM", "US"}};
+
 std::vector<winrt::hstring> RNLocalizeModule::getLocaleNames()
 {
   std::vector<winrt::hstring> locales;

--- a/windows/RNLocalize/RNLocalizeModule.h
+++ b/windows/RNLocalize/RNLocalizeModule.h
@@ -35,8 +35,8 @@ private:
     NumberFormatSettings getNumberFormatSettings(std::string);
     LocalizationConstants getExported();
 
-    const static std::array<std::string, 6> USES_FAHRENHEIT{{"BS", "BZ", "KY", "PR", "PW", "US"}};
-    const static std::array<std::string, 3> USES_IMPERIAL{{"LR", "MM", "US"}};
+    const static std::array<std::string, 6> USES_FAHRENHEIT;
+    const static std::array<std::string, 3> USES_IMPERIAL;
 };
 
 } // namespace winrt::RNLocalize


### PR DESCRIPTION
# Summary

Followup to @namrog84's PR, #138, to fix the build for Windows.  

Moves the initializers for `USES_FAHRENHEIT` and `USES_IMPERIAL` to `RNLocalizeModule.cpp`, to prevent errors like this one:

`9>E:\...\RNLocalizeModule.h(38,97): error C2864: 'winrt::RNLocalize::RNLocalizeModule::USES_FAHRENHEIT': a static data member with an in-class initializer must have non-volatile const integral type or be specified as 'inline' (compiling source file RNLocalizeModule.cpp)`

## Test Plan

No change to functionality - just a change to make the compiler happy.

Confirmed compiling and example app working properly with latest VS2019.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Windows |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
