### PR TITLE
Adds a note about the latin american regional settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ console.log(RNLocalize.getCountry());
 // -> "FR"
 ```
 
+#### Note
+
+Devices using Latin American regional settings will return "UN" instead of "419", as the latter is not a standard country code.
+
 ---
 
 ### getCalendar()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
When the device returns 419 as the country code for the Latin America and Caribbean region, the library returns "UN" instead. This should be documented.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I added the documentation in `README.md`
