### PR TITLE
Remove Microsoft.Xaml.UI dependency because it causes issue in RN65

### DIFF
--- a/windows/RNLocalize/RNLocalize.vcxproj
+++ b/windows/RNLocalize/RNLocalize.vcxproj
@@ -146,7 +146,6 @@
   </Target>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -154,6 +153,5 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.UI.Xaml.2.3.191129002\build\native\Microsoft.UI.Xaml.targets'))" />
   </Target>
 </Project>

--- a/windows/RNLocalize/packages.config
+++ b/windows/RNLocalize/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
-  <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
 </packages>

--- a/windows/RNLocalize/pch.h
+++ b/windows/RNLocalize/pch.h
@@ -8,19 +8,8 @@
 #include <windows.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
-#include <winrt/Windows.UI.Xaml.Controls.h>
-#include <winrt/Windows.UI.Xaml.Data.h>
-#include <winrt/Windows.UI.Xaml.Interop.h>
-#include <winrt/Windows.UI.Xaml.Markup.h>
-#include <winrt/Windows.UI.Xaml.Navigation.h>
-#include <winrt/Windows.UI.Xaml.h>
+#include <winrt/Windows.Globalization.h>
 
 #include <winrt/Microsoft.ReactNative.h>
 
-#include <winrt/Microsoft.UI.Xaml.Automation.Peers.h>
-#include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
-#include <winrt/Microsoft.UI.Xaml.Controls.h>
-#include <winrt/Microsoft.UI.Xaml.Media.h>
-#include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
 using namespace winrt::Windows::Foundation;


### PR DESCRIPTION
# Summary


RN65 causes issue with having multiple versions of WinUI (Microsoft.UI.Xaml) so everyone has to be on the same version for RNW65 (WinUI 2.6).
However RNLocalize doesn't actually use any functionality from Microsoft.UI.Xaml, so it can be removed and prevent further issues.

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
Make RNLocalize work more easily with RNW65

* What is the feature? (if applicable)
Remove unused dependency.
* How did you implement the solution?
Removed the dependency


## Test Plan

### What's required for testing (prerequisites)?
If it can still compile/link, then its not missing any compile time dependencies. 

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)

Tagging #170 