### PR TITLE
Use LocaleList for API > 24

### DIFF
--- a/android/src/main/java/com/zoontek/rnlocalize/RNLocalizeModule.java
+++ b/android/src/main/java/com/zoontek/rnlocalize/RNLocalizeModule.java
@@ -117,14 +117,15 @@ public class RNLocalizeModule extends ReactContextBaseJavaModule {
 
   private @NonNull List<Locale> getLocales() {
     List<Locale> locales = new ArrayList<>();
-    Configuration config = getReactApplicationContext()
-      .getResources()
-      .getConfiguration();
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+      Configuration config = getReactApplicationContext()
+        .getResources()
+        .getConfiguration();
+
       locales.add(config.locale);
     } else {
-      LocaleList list = config.getLocales();
+      LocaleList list = LocaleList.getDefault();
 
       for (int i = 0; i < list.size(); i++) {
         locales.add(list.get(i));


### PR DESCRIPTION
# Summary

In our application, the call to RNLocalize.getLocales() would not be in the same order that the user's system settings were in.  During debugging I found that Configuration.getLocales returned a different order than LocaleList.getDefault.  It didn't seem to be deterministic or repeatable all the time.  

NOTE:

Before I submitted this PR I went back to verify my assumptions, including making sure I was up to date on the library.  After a lot of testing, I couldn't reproduce the problem that I first noticed with Configuration.getLocales.  So consider this PR a theoretical solution to a problem that may or may not exist.  From my reading, LocaleList.getDefault() seems to be a more appropriate method, but that's just an opinion based off of reading.

## Test Plan

I tested the change locally in our application utilizing yalc, and in the android example application.  I verified that changing the system settings took affect immediately.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
