### PR TITLE
Fix findBestAvailableLanguage not respecting script code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,6 @@ export function findBestAvailableLanguage<T extends string>(
       }
     }
   }
-
-  return undefined
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,15 +58,18 @@ export function findBestAvailableLanguage<T extends string>(
       return { languageTag: languageTags[languageTagIndex], isRTL };
     }
 
-    const partialTagIndex = loweredLanguageTags.indexOf(
-      (languageCode + "-" + countryCode).toLowerCase(),
-    );
-
-    if (partialTagIndex !== -1) {
-      return { languageTag: languageTags[partialTagIndex], isRTL };
-    }
-
     if (scriptCode != null && scriptCode.length > 0) {
+      const partialTagByScriptCodeAndCountryCodeIndex =
+        loweredLanguageTags.indexOf(
+          (languageCode + '-' + scriptCode + '-' + countryCode).toLowerCase(),
+        )
+
+      if (partialTagByScriptCodeAndCountryCodeIndex !== -1) {
+        return {
+          languageTag: languageTags[partialTagByScriptCodeAndCountryCodeIndex],
+          isRTL,
+        }
+      }
       const partialTagByScriptCodeIndex = loweredLanguageTags.indexOf(
         (languageCode + '-' + scriptCode).toLowerCase(),
       )
@@ -74,6 +77,14 @@ export function findBestAvailableLanguage<T extends string>(
       if (partialTagByScriptCodeIndex !== -1) {
         return { languageTag: languageTags[partialTagByScriptCodeIndex], isRTL }
       }
+    }
+
+    const partialTagIndex = loweredLanguageTags.indexOf(
+      (languageCode + "-" + countryCode).toLowerCase(),
+    );
+
+    if (partialTagIndex !== -1) {
+      return { languageTag: languageTags[partialTagIndex], isRTL };
     }
 
     const languageCodeIndex = loweredLanguageTags.indexOf(

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,51 +50,24 @@ export function findBestAvailableLanguage<T extends string>(
     const currentLocale = locales[i];
     const { languageTag, languageCode, countryCode, scriptCode, isRTL } = currentLocale;
 
-    const languageTagIndex = loweredLanguageTags.indexOf(
-      languageTag.toLowerCase(),
-    );
+    const combinations = [
+      languageTag,
+      (scriptCode != null && scriptCode.length > 0) ? (languageCode + '-' + scriptCode) : null,
+      (languageCode + "-" + countryCode),
+      languageCode
+    ].filter((combination): combination is string  => combination != null)
 
-    if (languageTagIndex !== -1) {
-      return { languageTag: languageTags[languageTagIndex], isRTL };
-    }
+    for (let j = 0; j < combinations.length; j++) {
+      const loweredCombination = combinations[j].toLowerCase()
+      const matchedIndex = loweredLanguageTags.indexOf(loweredCombination)
 
-    if (scriptCode != null && scriptCode.length > 0) {
-      const partialTagByScriptCodeAndCountryCodeIndex =
-        loweredLanguageTags.indexOf(
-          (languageCode + '-' + scriptCode + '-' + countryCode).toLowerCase(),
-        )
-
-      if (partialTagByScriptCodeAndCountryCodeIndex !== -1) {
-        return {
-          languageTag: languageTags[partialTagByScriptCodeAndCountryCodeIndex],
-          isRTL,
-        }
+      if (matchedIndex !== -1) {
+        return { languageTag: languageTags[matchedIndex], isRTL };
       }
-      const partialTagByScriptCodeIndex = loweredLanguageTags.indexOf(
-        (languageCode + '-' + scriptCode).toLowerCase(),
-      )
-
-      if (partialTagByScriptCodeIndex !== -1) {
-        return { languageTag: languageTags[partialTagByScriptCodeIndex], isRTL }
-      }
-    }
-
-    const partialTagIndex = loweredLanguageTags.indexOf(
-      (languageCode + "-" + countryCode).toLowerCase(),
-    );
-
-    if (partialTagIndex !== -1) {
-      return { languageTag: languageTags[partialTagIndex], isRTL };
-    }
-
-    const languageCodeIndex = loweredLanguageTags.indexOf(
-      languageCode.toLowerCase(),
-    );
-
-    if (languageCodeIndex !== -1) {
-      return { languageTag: languageTags[languageCodeIndex], isRTL };
     }
   }
+
+  return undefined
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export function findBestAvailableLanguage<T extends string>(
 
   for (let i = 0; i < locales.length; i++) {
     const currentLocale = locales[i];
-    const { languageTag, languageCode, countryCode, isRTL } = currentLocale;
+    const { languageTag, languageCode, countryCode, scriptCode, isRTL } = currentLocale;
 
     const languageTagIndex = loweredLanguageTags.indexOf(
       languageTag.toLowerCase(),
@@ -64,6 +64,16 @@ export function findBestAvailableLanguage<T extends string>(
 
     if (partialTagIndex !== -1) {
       return { languageTag: languageTags[partialTagIndex], isRTL };
+    }
+
+    if (scriptCode != null && scriptCode.length > 0) {
+      const partialTagByScriptCodeIndex = loweredLanguageTags.indexOf(
+        (languageCode + '-' + scriptCode).toLowerCase(),
+      )
+
+      if (partialTagByScriptCodeIndex !== -1) {
+        return { languageTag: languageTags[partialTagByScriptCodeIndex], isRTL }
+      }
     }
 
     const languageCodeIndex = loweredLanguageTags.indexOf(


### PR DESCRIPTION
# Summary

It is found that after 2.1.7, the `findBestAvailableLanguage` behaved differently from previous version, mainly due to missing check with script code of language. 

For instance, in our app, we are using `languageTags` with `['en', 'zh-Hant']`. With the device recognizing the language with the locale 
```json
[
   {
      "countryCode":"HK",
      "isRTL":false,
      "languageCode":"zh",
      "languageTag":"zh-Hant-HK",
      "scriptCode":"Hant"
   },
   {
      "countryCode":"US",
      "isRTL":false,
      "languageCode":"ja",
      "languageTag":"ja-US"
   },
   {
      "countryCode":"US",
      "isRTL":false,
      "languageCode":"yue",
      "languageTag":"yue-Hant-US",
      "scriptCode":"Hant"
   }
]
```
we experience failed in finding best available language, with `undefined` returned even `zh-Hant-HK` is is the locale. 

After checking the change in v2.1.7, noticed that it was originally respecting the script code instead of country code, and changed to respect only country code since v2.1.7. 

This change is to also check the language against script code during find best available language, with the order of

1. `(languageTag)` match *(original logic)*
2. `(languageCode)-(scriptCode)-(countryCode)` included
3. `(languageCode)-(scriptCode)` included
4. `(languageCode)-(countryCode)` included *(original logic)*
5. `(languageCode)` included *(original logic)*

Please feel free to comment. Thanks

## Test Plan

### What's required for testing (prerequisites)?

Select the mobile device language order to Chinese (Hong Kong) or Chinese (Taiwan) as high order

### What are the steps to reproduce (after prerequisites)?

Use `findBestAvailableLanguage` with following sample
```ts
console.log(findBestAvailableLangauge(['en', 'zh-Hant'])
```

Before the fix, it prints
```
undefined
```

After the change, it recognizes as 
```
{"isRTL": false, "languageTag": "zh-Hant"}
```


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
