### PR TITLE
fix(windows): Change WindowsTargetPlatformVersion to 10.0

### DIFF
--- a/windows/RNLocalize/RNLocalize.vcxproj
+++ b/windows/RNLocalize/RNLocalize.vcxproj
@@ -13,7 +13,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
## Description

Changed to general version for WindowsTargetPlatformVersion 

Using an explicit version of WindowsTargetPlatformVersion requires that specific windows SDK version to be installed on the machine.  
In Visual Studio 2017 (version 15 or build tools 141) and earlier it was required but as of Visual Studio 2019 (v16 or v142) and Visual Studio 2022(v17 or v143) you can simply specify "10.0".  This allows a lot more flexibility to the developer or build machine as there is a growing number of different windows 10 SDK out there now. 


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Windows |    ✅     |


Misc notes: Newer versions of azure hosted windows images have a different subset of windows 10 sdk version installed. And requiring a specific version can cause variety of issues and headaches. 
VS2022 Azure Window image has
10.0.17763.0, 10.0.19041.0, 10.0.20348.0, 10.0.22000.0
VS2019 Azure Window image had
10.0.14393.0, 10.0.16299.0, 10.0.17134.0, 10.0.17763.0, 10.0.18362.0, 10.0.19041.0, 10.0.20348.0, 10.0.22000.0

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
