### PR TITLE
fix(windows): use Windows NLS APIs for getNumberFormatSettings

### DIFF
--- a/windows/RNLocalize/RNLocalizeModule.cpp
+++ b/windows/RNLocalize/RNLocalizeModule.cpp
@@ -159,22 +159,22 @@ std::string RNLocalizeModule::getTimeZone()
   return timeZoneString;
 }
 
+std::wstring RNLocalizeModule::getNlsLocaleInfo(std::wstring localeName, LCTYPE localeInformationType) {
+  constexpr int32_t NLS_BUFFER_SIZE = 512;
+
+  wchar_t nlsBuffer[NLS_BUFFER_SIZE];
+  GetLocaleInfoEx(localeName.c_str(), localeInformationType, nlsBuffer, NLS_BUFFER_SIZE);
+  return std::wstring(nlsBuffer);
+}
+
 NumberFormatSettings RNLocalizeModule::getNumberFormatSettings(std::string locale)
 {
   NumberFormatSettings numberFormatSettings;
 
-  // Use GetNumberFormatEx to get number formatting based on the passed locale.
-  std::wstring num1000(L"1000.00");
-
   std::wstring wStrLocale = std::wstring(locale.begin(), locale.end());
-  const int numberFormatBufferLength = 9;
-  wchar_t numberFormatBuffer[numberFormatBufferLength];
-  GetNumberFormatEx(wStrLocale.c_str(), 0, num1000.c_str(), nullptr, numberFormatBuffer, numberFormatBufferLength);
-  std::string formattedString = winrt::to_string(numberFormatBuffer);
 
-  // Note: The index is intentionally 5 because the output is expected to be something like "1,000.00" and not the original input of "1000.00"
-  numberFormatSettings.decimalSeparator = formattedString.substr(5, 1);
-  numberFormatSettings.groupingSeparator = formattedString.substr(1, 1);
+  numberFormatSettings.decimalSeparator = getNlsLocaleInfo(wStrLocale, LOCALE_SDECIMAL);
+  numberFormatSettings.groupingSeparator = getNlsLocaleInfo(wStrLocale, LOCALE_STHOUSAND);
 
   return numberFormatSettings;
 }

--- a/windows/RNLocalize/RNLocalizeModule.h
+++ b/windows/RNLocalize/RNLocalizeModule.h
@@ -32,6 +32,7 @@ private:
     std::string getScriptCode(winrt::hstring);
     std::string getCalendar();
     std::string getTimeZone();
+    std::wstring getNlsLocaleInfo(std::wstring, LCTYPE);
     NumberFormatSettings getNumberFormatSettings(std::string);
     LocalizationConstants getExported();
 

--- a/windows/RNLocalize/RNLocalizeModuleTypes.h
+++ b/windows/RNLocalize/RNLocalizeModuleTypes.h
@@ -31,10 +31,10 @@ REACT_STRUCT(NumberFormatSettings)
 struct NumberFormatSettings
 {
     REACT_FIELD(decimalSeparator, L"decimalSeparator")
-    std::string decimalSeparator;
+    std::wstring decimalSeparator;
 
     REACT_FIELD(groupingSeparator, L"groupingSeparator")
-    std::string groupingSeparator;
+    std::wstring groupingSeparator;
 };
 
 REACT_STRUCT(LocalizationConstants)


### PR DESCRIPTION
## Summary
`RNLocalizeModule::getNumberFormatSettings` was using a Windows API to format a number (1,000) and then extract format characters from there. It was relying on the fact that the length is greater than 5, which isn't always the case as on Windows users can heavily customize decimal number formatting by for instance removing the whole decimal part of the displayed number. In this case, `getNumberFormatSettings` was just crashing.

Instead of trying to get localization information based on the output of the format method, this commit uses Windows NLS APIs (National Language Support) to directly retrieves the settings.
This is what .NET Runtime is doing as a comparison for [System.Globalization.NumberFormatInfo.NumberGroupSeparator](https://github.com/dotnet/runtime/blob/315e93123d08e91d3f422adaead022a81e503798/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs#L2223) then finally calling [GetLocaleInfoEx](https://github.com/dotnet/runtime/blob/c59b5171e4fb2b000108bec965f8ce443cb95a12/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs#L17)
Even though this isn't a WinRT API, it's still accessible from UWP apps.

In addition to fixing a potential crash, it also fixes encoding as some languages use Unicode characters in their number formats. For instance, in fr-FR, "1,000" is "1 000,00" with a "," as a decimal separator and " " (U+202F - Narrow non-breaking space) as thousand separator.

## Test Plan
I was able to reproduce the crash by putting 0 digits after the decimal and no digit grouping in Windows region's number formatting settings in our main RN project (crash occurs at module initialization).

I've built and run this code in the same RN project and made it work.

## Compatibility
Windows only

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- Doesn't apply: I have tested this on a device and a simulator
- Doesn't apply (this isn't an API change): I added the documentation in `README.md`
- Doesn't apply (this isn't an API change): I added a sample use of the API in the example project (`example/src/App.js`)
