### PR TITLE
Avoid jest error when using on setup file

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,9 +420,9 @@ Because it's a native module, you need to mock this package.<br />
 The package provides a default mock you may use in your \_\_mocks\_\_/react-native-localize.js or jest.setup.js.
 
 ```js
-import RNLocalize from "react-native-localize/mock";
+import mockRNLocalize from "react-native-localize/mock";
 
-jest.mock("react-native-localize", () => RNLocalize);
+jest.mock("react-native-localize", () => mockRNLocalize);
 ```
 
 ## Add project's supported localizations (iOS)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Update documentation regarding component mocking on `jest.setup.js` file. Without prefixing the component name with the word `mock`, `jest` will throw an error (https://jestjs.io/docs/manual-mocks). 

<img width="1434" alt="Screenshot 2022-11-09 at 15 53 11" src="https://user-images.githubusercontent.com/29999392/200863249-b32356d6-429d-4de0-8714-9d1aaca76435.png">

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I added a sample use of the API in the example project (`example/src/App.js`)
