### PR TITLE
fix: add missing mocks

### DIFF
--- a/mock/index.ts
+++ b/mock/index.ts
@@ -36,6 +36,7 @@ export default {
   getTemperatureUnit,
   getTimeZone,
   uses24HourClock,
+  usesAutoDateAndTime,
   usesMetricSystem,
 
   findBestAvailableLanguage,

--- a/mock/index.ts
+++ b/mock/index.ts
@@ -21,6 +21,7 @@ export const getCurrencies = () => ["USD", "EUR"]; // can be empty array
 export const getTemperatureUnit = () => "celsius"; // or "fahrenheit"
 export const getTimeZone = () => "Europe/Paris"; // the timezone you want
 export const uses24HourClock = () => true;
+export const usesAutoDateAndTime = () => true;
 export const usesMetricSystem = () => true;
 
 export const addEventListener = jest.fn();

--- a/mock/index.ts
+++ b/mock/index.ts
@@ -22,6 +22,7 @@ export const getTemperatureUnit = () => "celsius"; // or "fahrenheit"
 export const getTimeZone = () => "Europe/Paris"; // the timezone you want
 export const uses24HourClock = () => true;
 export const usesAutoDateAndTime = () => true;
+export const usesAutoTimeZone = () => true;
 export const usesMetricSystem = () => true;
 
 export const addEventListener = jest.fn();
@@ -37,6 +38,7 @@ export default {
   getTimeZone,
   uses24HourClock,
   usesAutoDateAndTime,
+  usesAutoTimeZone,
   usesMetricSystem,
 
   findBestAvailableLanguage,


### PR DESCRIPTION
Missing jest mock when using the following config

```ts
import mockRNLocalize from 'react-native-localize/mock';
jest.mock('react-native-localize', () => mockRNLocalize);
```

<img width="540" alt="Screen Shot 2023-03-09 at 9 05 06 PM" src="https://user-images.githubusercontent.com/2933593/224228297-4bd7ea92-cbd5-4ce4-ae0e-02a92334e20b.png">
