### PR TITLE
Add visionOS support

### DIFF
--- a/RNLocalize.podspec
+++ b/RNLocalize.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = package["author"]
   s.homepage     = package["homepage"]
 
-  s.platforms    = { :ios => "12.4", :tvos => "12.4", :osx => "10.15" }
+  s.platforms    = { :ios => "12.4", :tvos => "12.4", :osx => "10.15", :visionos => 1.0 }
   s.requires_arc = true
 
   s.source       = { :git => package["repository"]["url"], :tag => s.version }


### PR DESCRIPTION
# Summary

Add visionOS support by adding the platform to the podspec

## Test Plan

Normally, I would update the test app to use [react-native-test-app](https://github.com/microsoft/react-native-test-app), which I added visionOS support to. However, that test app doesn't support web, and I see there is a web example in this repo. I did however, test localize in a different  packages' test app on visionOS by patching the package: https://github.com/react-native-datetimepicker/datetimepicker/pull/879 

And it compiled fine :)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| visionOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/src/App.js`)
