### PR TITLE
bugfix: Added support for language where script was not being considered

### DIFF
--- a/android/src/main/java/com/zoontek/rnlocalize/RNLocalizeModuleImpl.kt
+++ b/android/src/main/java/com/zoontek/rnlocalize/RNLocalizeModuleImpl.kt
@@ -32,6 +32,9 @@ object RNLocalizeModuleImpl {
 
   private val USES_FAHRENHEIT = listOf("BS", "BZ", "KY", "PR", "PW", "US")
   private val USES_IMPERIAL = listOf("LR", "MM", "US")
+  // Scripts that are RTL regardless of language default.
+  // needed for pre 21
+  private val RTL_SCRIPTS = setOf("Arab", "Hebr", "Syrc", "Thaa", "Nkoo", "Adlm", "Rohg")
 
   // Internal
 
@@ -158,6 +161,8 @@ object RNLocalizeModuleImpl {
       val countryCode = getCountryCodeForLocale(systemLocale).ifEmpty { currentCountryCode }
 
       val languageTag = createLanguageTag(languageCode, scriptCode, countryCode)
+      // needed for pre 21, post 21 TextUtils.getLayoutDirectionFromLocale should handle things.
+      val rtlByScript = scriptCode.isNotEmpty() && RTL_SCRIPTS.contains(scriptCode)
 
       val locale = Arguments.createMap().apply {
         putString("languageCode", languageCode)
@@ -165,7 +170,7 @@ object RNLocalizeModuleImpl {
         putString("languageTag", languageTag)
 
         val rtl = TextUtils.getLayoutDirectionFromLocale(systemLocale) == View.LAYOUT_DIRECTION_RTL
-        putBoolean("isRTL", rtl)
+        putBoolean("isRTL", rtl || rtlByScript)
 
         if (scriptCode.isNotEmpty()) {
           putString("scriptCode", scriptCode)

--- a/ios/RNLocalize.mm
+++ b/ios/RNLocalize.mm
@@ -31,6 +31,17 @@ RCT_EXPORT_MODULE();
   return [languageTag stringByAppendingFormat:@"-%@", countryCode];
 }
 
+// Common right-to-left scripts you'll actually encounter in apps.
+NSSet<NSString *> *rtlScripts = [NSSet setWithArray:@[
+    @"Arab", // Arabic (incl. Jawi, Shahmukhi, Sorani, etc.)
+    @"Hebr", // Hebrew
+    @"Syrc", // Syriac
+    @"Thaa", // Thaana (Dhivehi)
+    @"Nkoo", // N’Ko
+    @"Adlm", // Adlam (Fula)
+    @"Rohg"  // Hanifi Rohingya
+]];
+
 // Implementation
 
 - (NSString *)getCalendarImpl {
@@ -112,6 +123,7 @@ RCT_EXPORT_MODULE();
     NSString *scriptCode = [systemLocale objectForKey:NSLocaleScriptCode];
     NSString *countryCode = [self getCountryCodeForLocale:systemLocale];
     bool isRTL = [NSLocale characterDirectionForLanguage:languageCode] == NSLocaleLanguageDirectionRightToLeft;
+    bool isRTLScript = (scriptCode && [rtlScripts containsObject:scriptCode]);
 
     if (countryCode == nil)
       countryCode = [self getCountryImpl];
@@ -124,7 +136,7 @@ RCT_EXPORT_MODULE();
       @"languageCode": languageCode,
       @"countryCode": countryCode,
       @"languageTag": languageTag,
-      @"isRTL": @(isRTL),
+      @"isRTL": @(isRTL || isRTLScript),
     }];
 
     if (scriptCode != nil)


### PR DESCRIPTION
# Summary

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
Currently the libary returns `false` for `isRTL` in the `getLocales` API for `ms-Arab` locale on iOS. The reason here is that it does not consider the script value when determining the `isRTL` value.

* What is the feature? (if applicable)
N/A

* How did you implement the solution?
Added needed support on both android and iOS

* What areas of the library does it impact?
`getLocales` API.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Nothing different than whats needed today to test this library.

### What are the steps to test it (after prerequisites)?
Change phone language on iOS to Malay Arabic (Android currently does not support it in default list)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
~- [ ] I added the documentation in `README.md`~
~- [ ] I added a sample use of the API in the example project (`example/src/App.js`)~
