### PR TITLE
Improve findBestLanguageTag function to optionally return a language even if it's from another country

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,21 +376,41 @@ Returns the best language tag possible and its reading direction. Useful to pick
 > [!NOTE]
 >
 > It respects the user preferred languages list order (see [explanations](https://github.com/zoontek/react-native-localize/issues/57#issuecomment-508456427)).
+>
+> If you care more about the language than the country, you can set the optional `preferFirstMatchingLanguage` parameter to `true`. In that case, if the user prefers "en-GB" but your app only supports "en-US", it will use the latter.
 
 #### Method type
 
 ```ts
 type findBestLanguageTag = (
   languageTags: string[],
-) => { languageTag: string; isRTL: boolean } | void;
+  preferFirstMatchingLanguage?: boolean,
+) => { languageTag: string; isRTL: boolean } | undefined;
 ```
 
-#### Usage example
+#### Usage examples
+
+Assuming the user preferred language list order is: `it-IT` > `en-GB` > `fr-FR`
 
 ```ts
 import { findBestLanguageTag } from "react-native-localize";
 
-console.log(findBestLanguageTag(["en-US", "en", "fr"]));
+console.log(findBestLanguageTag(["fr", "en"]));
+// -> { languageTag: "en", isRTL: false }
+
+console.log(findBestLanguageTag(["fr-FR", "en-US"]));
+// -> { languageTag: "fr-FR", isRTL: false }
+
+console.log(findBestLanguageTag(["fr-FR", "en-US"], true));
+// -> { languageTag: "en-US", isRTL: false }
+
+console.log(findBestLanguageTag(["fr-FR", "en-US", "en"]));
+// -> { languageTag: "en", isRTL: false }
+
+console.log(findBestLanguageTag(["de-DE", "en-US"]));
+// -> undefined
+
+console.log(findBestLanguageTag(["de-DE", "en-US"], true));
 // -> { languageTag: "en-US", isRTL: false }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 import { getLocales } from "./module";
 
+function isMatchingLanguage(languageTag: string, languageCode: string) {
+  return languageTag.toLowerCase().split("-")[0] === languageCode.toLowerCase();
+}
+
 export function findBestLanguageTag<T extends string>(
   languageTags: ReadonlyArray<T>,
+  preferFirstMatchingLanguage?: boolean,
 ): { languageTag: T; isRTL: boolean } | undefined {
   const locales = getLocales();
   const loweredLanguageTags = languageTags.map((tag) => tag.toLowerCase());
+
+  let firstMatch: ReturnType<typeof findBestLanguageTag<T>>;
 
   for (let i = 0; i < locales.length; i++) {
     const currentLocale = locales[i];
@@ -15,6 +22,10 @@ export function findBestLanguageTag<T extends string>(
 
     const { languageTag, languageCode, scriptCode, countryCode, isRTL } =
       currentLocale;
+
+    if (firstMatch !== undefined && !isMatchingLanguage(firstMatch.languageTag, languageCode)) {
+      continue; // when preferFirstMatchingLanguage is true and we already found a matching language, ignore any other languages
+    }
 
     const combinaisons = [
       languageTag,
@@ -37,6 +48,17 @@ export function findBestLanguageTag<T extends string>(
         return { languageTag, isRTL };
       }
     }
+
+    if (preferFirstMatchingLanguage === true && firstMatch === undefined) {
+      const languageTag = languageTags.find((tag) => isMatchingLanguage(tag, languageCode));
+      if (languageTag) {
+        firstMatch = { languageTag, isRTL };
+      }
+    }
+  }
+
+  if (firstMatch !== undefined) {
+    return firstMatch;
   }
 }
 


### PR DESCRIPTION
# Summary

This PR implements the changes I proposed in https://github.com/zoontek/react-native-localize/issues/226#issuecomment-3282512305

- Added an optional `preferFirstMatchingLanguage` parameter to the `findBestLanguageTag` function.
- When this parameter is set to `true`, the function will ignore the user's country preference in certain cases.
- Updated the Readme with usage examples.

This change is non-breaking. The behavior of the `findBestLanguageTag` function when called without the new parameter remains unchanged.

## Test Plan

### What's required for testing (prerequisites)?

You can use the example app for testing.

### What are the steps to test it (after prerequisites)?

Run the example app and try out different variations of OS language settings and `findBestLanguageTag` function parameters.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I added a sample use of the API in the example project (`example/src/App.js`) <-- A sample for `findBestLanguageTag` already exists
