### PR TITLE
Fix Expo plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "/mock",
     "/src",
     "RNLocalize.podspec",
+    "app.plugin.js",
     "package.json"
   ],
   "repository": {


### PR DESCRIPTION
# Summary

When installing the library, Expo does not recognize it as a plugin because the distributed package is missing the `app.plugin.js` file. I added it to the files section in `package.json` and now it works (for me).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/src/App.js`)
